### PR TITLE
Make `message_id` nullable.

### DIFF
--- a/database/migrations/2018_09_20_174247_create_postmark_webhook_logs_table.php
+++ b/database/migrations/2018_09_20_174247_create_postmark_webhook_logs_table.php
@@ -18,7 +18,7 @@ class CreatePostmarkWebhookLogsTable extends Migration
     {
         Schema::create($this->table_name, function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('message_id', 100);
+            $table->string('message_id', 100)->nullable();
             $table->string('record_type', 32);
             $table->string('email')->index();
             $table->json('payload');

--- a/src/Events/PostmarkWebhookCalled.php
+++ b/src/Events/PostmarkWebhookCalled.php
@@ -16,7 +16,7 @@ class PostmarkWebhookCalled
     /** @var array */
     public $payload;
 
-    public function __construct(string $email, string $recordType, string $messageId, array $payload)
+    public function __construct(string $email, string $recordType, ?string $messageId, array $payload)
     {
         $this->email = $email;
         $this->recordType = $recordType;


### PR DESCRIPTION
In some instances message_id is not provided, for example when subscription status is changed manually by the site owner in postmarkapp.com directly.