### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0"
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.5 || ^5.0 || ^6.0",


### PR DESCRIPTION
Added illuminate/support version for Laravel 9.x compatibility

I think this is all that is needed.. tested on a fresh L9 install and it clears any composer install errors.